### PR TITLE
Support for apps in different folders

### DIFF
--- a/mongonaut/urls.py
+++ b/mongonaut/urls.py
@@ -10,27 +10,27 @@ urlpatterns = patterns('',
         name="index"
     ),
     url(
-        regex=r'^(?P<app_label>[_\-\w]+)/(?P<document_name>[_\-\w]+)/$',
+        regex=r'^(?P<app_label>[_\-\w.]+)/(?P<document_name>[_\-\w]+)/$',
         view=views.DocumentListView.as_view(),
         name="document_list"
     ),
     url(
-        regex=r'^(?P<app_label>[_\-\w]+)/(?P<document_name>[_\-\w]+)/add/$',
+        regex=r'^(?P<app_label>[_\-\w.]+)/(?P<document_name>[_\-\w]+)/add/$',
         view=views.DocumentAddFormView.as_view(),
         name="document_detail_add_form"
     ),
     url(
-        regex=r'^(?P<app_label>[_\-\w]+)/(?P<document_name>[_\-\w]+)/(?P<id>[\w]+)/$',
+        regex=r'^(?P<app_label>[_\-\w.]+)/(?P<document_name>[_\-\w]+)/(?P<id>[\w]+)/$',
         view=views.DocumentDetailView.as_view(),
         name="document_detail"
     ),
     url(
-        regex=r'^(?P<app_label>[_\-\w]+)/(?P<document_name>[_\-\w]+)/(?P<id>[\w]+)/edit/$',
+        regex=r'^(?P<app_label>[_\-\w.]+)/(?P<document_name>[_\-\w]+)/(?P<id>[\w]+)/edit/$',
         view=views.DocumentEditFormView.as_view(),
         name="document_detail_edit_form"
     ),
     url(
-        regex=r'^(?P<app_label>[_\-\w]+)/(?P<document_name>[_\-\w]+)/(?P<id>[\w]+)/delete/$',
+        regex=r'^(?P<app_label>[_\-\w.]+)/(?P<document_name>[_\-\w]+)/(?P<id>[\w]+)/delete/$',
         view=views.DocumentDeleteView.as_view(),
         name="document_delete"
     )


### PR DESCRIPTION
I have all my apps under apps/ folder. If I try to register MongoAdmin on a model from the app that has the following structure: project.apps.app.models it won't work.
This change should fix this, and "app_label" should become the whole path to the app.