### PR TITLE
Regex for <document_name> updated. 

### DIFF
--- a/examples/blog/articles/models.py
+++ b/examples/blog/articles/models.py
@@ -23,6 +23,14 @@ class User(Document):
     first_name = StringField(max_length=50)
     last_name = StringField(max_length=50)
 
+    meta = {'allow_inheritance': True}
+
+    def __unicode__(self):
+        return self.email
+
+class NewUser(User):
+    new_field = StringField()
+
     def __unicode__(self):
         return self.email
 

--- a/examples/blog/articles/mongoadmin.py
+++ b/examples/blog/articles/mongoadmin.py
@@ -1,6 +1,6 @@
 from mongonaut.sites import MongoAdmin
 
-from articles.models import Post, User
+from articles.models import Post, User, NewUser
 
 
 class PostAdmin(MongoAdmin):
@@ -18,7 +18,7 @@ class PostAdmin(MongoAdmin):
         return True
 
     search_fields = ('title', 'id')
-    list_fields = ('title', "published", "pub_date", "update_times")
+    list_fields = ('title', 'author', "published", "pub_date", "update_times")
 
 
 class UserAdmin(MongoAdmin):
@@ -36,3 +36,4 @@ class UserAdmin(MongoAdmin):
 
 Post.mongoadmin = PostAdmin()
 User.mongoadmin = UserAdmin()
+NewUser.mongoadmin = UserAdmin()

--- a/mongonaut/urls.py
+++ b/mongonaut/urls.py
@@ -1,6 +1,4 @@
 from django.conf.urls import patterns, url
-
-
 from mongonaut import views
 
 urlpatterns = patterns('',
@@ -21,6 +19,8 @@ urlpatterns = patterns('',
     ),
     url(
         regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w\.]+)/(?P<id>[\w]+)/$',
+        # regex=r'^(?P<app_label>.+)/(?P<document_name>.+)/(?P<id>.+)/$',
+
         view=views.DocumentDetailView.as_view(),
         name="document_detail"
     ),
@@ -30,7 +30,7 @@ urlpatterns = patterns('',
         name="document_detail_edit_form"
     ),
     url(
-        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w\.]+)/(?P<id>[\w]+)/delete/$',
+        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w\self.]+)/(?P<id>[\w]+)/delete/$',
         view=views.DocumentDeleteView.as_view(),
         name="document_delete"
     )

--- a/mongonaut/urls.py
+++ b/mongonaut/urls.py
@@ -10,27 +10,27 @@ urlpatterns = patterns('',
         name="index"
     ),
     url(
-        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w]+)/$',
+        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w\.]+)/$',
         view=views.DocumentListView.as_view(),
         name="document_list"
     ),
     url(
-        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w]+)/add/$',
+        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w\.]+)/add/$',
         view=views.DocumentAddFormView.as_view(),
         name="document_detail_add_form"
     ),
     url(
-        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w]+)/(?P<id>[\w]+)/$',
+        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w\.]+)/(?P<id>[\w]+)/$',
         view=views.DocumentDetailView.as_view(),
         name="document_detail"
     ),
     url(
-        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w]+)/(?P<id>[\w]+)/edit/$',
+        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w\.]+)/(?P<id>[\w]+)/edit/$',
         view=views.DocumentEditFormView.as_view(),
         name="document_detail_edit_form"
     ),
     url(
-        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w]+)/(?P<id>[\w]+)/delete/$',
+        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w\.]+)/(?P<id>[\w]+)/delete/$',
         view=views.DocumentDeleteView.as_view(),
         name="document_delete"
     )

--- a/mongonaut/urls.py
+++ b/mongonaut/urls.py
@@ -19,7 +19,6 @@ urlpatterns = patterns('',
     ),
     url(
         regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w\.]+)/(?P<id>[\w]+)/$',
-        # regex=r'^(?P<app_label>.+)/(?P<document_name>.+)/(?P<id>.+)/$',
 
         view=views.DocumentDetailView.as_view(),
         name="document_detail"
@@ -30,7 +29,7 @@ urlpatterns = patterns('',
         name="document_detail_edit_form"
     ),
     url(
-        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w\self.]+)/(?P<id>[\w]+)/delete/$',
+        regex=r'^(?P<app_label>[_\-\w\.]+)/(?P<document_name>[_\-\w\.]+)/(?P<id>[\w]+)/delete/$',
         view=views.DocumentDeleteView.as_view(),
         name="document_delete"
     )

--- a/tests/url_tests.py
+++ b/tests/url_tests.py
@@ -1,0 +1,90 @@
+#coding: utf-8
+
+import unittest
+from django.test import RequestFactory
+from mongonaut.views import DocumentDetailView
+from common.utils import DummyUser 
+
+from mongoengine import *
+
+from examples.blog.articles.models import Post, User, NewUser
+
+from mongonaut.templatetags.mongonaut_tags import get_document_value
+from bson.objectid import ObjectId
+
+from importlib import import_module
+
+from django.core.urlresolvers import NoReverseMatch
+from django.conf import settings
+import django
+
+class IndexViewTests(unittest.TestCase):
+
+    def setUp(self):
+        self.req = RequestFactory().get('/')
+        django.setup()
+
+    def testURLResolver(self):
+        '''
+            Tests whether reverse function inside get_document_value can 
+            correctly return a document_detail url when given a set of:
+            <document_name> <app_label> and <id>
+            Both <document_name> and <app_label> will contain dots, eg.
+                <document_name> : 'User.NewUser'
+                <app_label>     : 'examples.blog.articles'
+        '''
+
+        urls_tmp = settings.ROOT_URLCONF
+        settings.ROOT_URLCONF = 'examples.blog.urls'
+
+        u = NewUser(email='test@test.com')
+        u.id=ObjectId('abcabcabcabc')
+
+        p = Post(author=u, title='Test')
+        p.id = ObjectId('abcabcabcabc')
+
+        match_found = True
+
+        try:
+            v = get_document_value(p, 'author')
+        except NoReverseMatch, e:
+            match_found = False
+
+        settings.ROOT_URLCONF = urls_tmp
+
+        self.assertEquals(match_found, True)
+
+    def testDetailViewRendering(self):
+        '''
+            Tries to render a detail view byt giving it data 
+            from examples.blog. As <app_label> and <document_name>
+            may contain dots, it checks whether NoReverseMatch exception
+            was raised.
+        '''
+
+        self.req.user = DummyUser()
+
+        urls_tmp = settings.ROOT_URLCONF
+        settings.ROOT_URLCONF = 'examples.blog.urls'
+
+        self.view = DocumentDetailView.as_view()(
+                        app_label='examples.blog.articles', 
+                        document_name='Post', 
+                        id=ObjectId('abcabcabcabc'),
+                        request=self.req, 
+                        models=import_module('examples.blog.articles.models')
+                    )
+
+        match_found = True
+
+        try:
+            self.view.render()
+        except NoReverseMatch, e:
+            match_found = False
+
+        settings.ROOT_URLCONF = urls_tmp
+        
+        self.assertEquals(match_found, True)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Regex for <document_name> in mongonaut's urls.py does not allow for dot (".") to be present in the name of the model. But MongoEngine gives names containing a dot when one model inherits after the other. For example, if a model inherits from "User" and it's named NewUser, then the whole name of the new model will be: User.NewUser. Mongonaut does not allow for those kind of names so I made a little change in the urls.py file.